### PR TITLE
Change - ToISO String to locale

### DIFF
--- a/src/app/dashboard/transactions/page.tsx
+++ b/src/app/dashboard/transactions/page.tsx
@@ -26,20 +26,15 @@ export default async function Page({
   const query = searchParams?.query || "";
   var date = new Date();
   const firstDay = new Date(date.getFullYear(), date.getMonth(), 1)
-    .toISOString()
+    .toLocaleDateString()
     .split("T")[0]
     .replace(/-/g, " ");
   const lastDay = new Date(date.getFullYear(), date.getMonth() + 1, 0)
-    .toISOString()
+    .toLocaleDateString()
     .split("T")[0]
     .replace(/-/g, " ");
   const dates = searchParams?.dates || firstDay + "to" + lastDay;
   const totalPages = await fetchTransactionPages(query, dates, session.user.id);
-
-  console.warn("Date: new Date()", date);
-  console.warn("Date: firstDay", firstDay);
-  console.warn("Date: lastDay", lastDay);
-  console.warn("Date: dates", dates);
 
   return (
     <div className="w-full">

--- a/src/app/ui/dashboard/sidenav.tsx
+++ b/src/app/ui/dashboard/sidenav.tsx
@@ -17,7 +17,7 @@ export default function SideNav() {
             <p className=" text-lg">CoupleCents</p>
           </div>
           <div className="m-auto text-secondary md:w-40 md:text-center">
-            <p className=" text-sm">v0.4.3</p>
+            <p className=" text-sm">v0.4.4</p>
           </div>
         </div>
       </Link>


### PR DESCRIPTION
This PR fixes the issue of the UTC offset

Example:
Last day of the month after 6pm UTC is Augst 1st, so then dates filters are not correct between client and server dates. Causing that the transactions are incorrect in this case empty.